### PR TITLE
Add synchronous `@confirm` macro

### DIFF
--- a/src/environment/electron/IpcEvents.ts
+++ b/src/environment/electron/IpcEvents.ts
@@ -21,7 +21,7 @@ export type IpcMainEventListenerMap = {
 
 export type IpcRendererEventListeners = {
   clearLogs(): Promise<void>;
-  confirm(timeout: number, prompt: string, ...options: TestConfirmOption[]): Promise<string>;
+  confirm(lineno: number, timeout: number, prompt: string, ...options: TestConfirmOption[]): Promise<string>;
   interrupt(): Promise<void>;
   setScriptFileName(fileName: string): Promise<void>;
 } & {

--- a/src/environment/electron/IpcEvents.ts
+++ b/src/environment/electron/IpcEvents.ts
@@ -1,4 +1,5 @@
 import {TestScriptEvent, TestScriptListeners} from "../../script/TestScriptEvents";
+import {TestConfirmOption} from "../../script/TestScript";
 
 /*
  * Events from renderer to main
@@ -19,11 +20,12 @@ export type IpcMainEventListenerMap = {
  */
 
 export type IpcRendererEventListeners = {
-  clearLogs(): void;
-  interrupt(): void;
-  setScriptFileName(fileName: string): void;
+  clearLogs(): Promise<void>;
+  confirm(timeout: number, prompt: string, ...options: TestConfirmOption[]): Promise<string>;
+  interrupt(): Promise<void>;
+  setScriptFileName(fileName: string): Promise<void>;
 } & {
-  [event in TestScriptEvent]: (lineno: number, ...arg: Parameters<TestScriptListeners[event]>) => void;
+  [event in TestScriptEvent]: (lineno: number, ...arg: Parameters<TestScriptListeners[event]>) => Promise<ReturnType<TestScriptListeners[event]>>;
 };
 
 export type IpcRendererEvent = keyof IpcRendererEventListeners;

--- a/src/environment/electron/index.ts
+++ b/src/environment/electron/index.ts
@@ -60,8 +60,8 @@ export const logStatus = async (status: string, clazz?: string[]): Promise<void>
   if (clazz?.length) {
     document.querySelectorAll("#sys_col_bar").forEach(e => {
       const [unset, set] = clazz;
-      if (unset) e.classList.remove(unset);
-      if (set) e.classList.add(set);
+      if (unset) unset.split(/\s+/).forEach(clazz => e.classList.remove(clazz));
+      if (set) set.split(/\s+/).forEach(clazz => e.classList.add(clazz));
     });
   }
 };
@@ -82,8 +82,8 @@ export const clearLogs = async (): Promise<void> => {
 
 export const getTestResults = () => ({...tests});
 
-export const confirm = async (timeout: number, prompt: string, ...options: TestConfirmOption[]): Promise<string> => {
-  await logMessage(-1, "question", prompt);
+export const confirm = async (lineno: number, timeout: number, prompt: string, ...options: TestConfirmOption[]): Promise<string> => {
+  await logMessage(lineno, "question", prompt);
   const row = document.createElement("p");
   row.className = `sys_col_message sys_col_row`;
   return new Promise((resolve, reject) => {
@@ -92,21 +92,21 @@ export const confirm = async (timeout: number, prompt: string, ...options: TestC
         row.parentNode?.removeChild(row);
         reject(new Error("Timeout"));
       },
-      Math.max(timeout, 10_000),
+      Math.max(timeout, 30_000),
     );
 
     const clearButtons = () => {
       clearTimeout(timeoutId);
-      row.querySelectorAll("button").forEach(btn => {
+      row.querySelectorAll('input[type="button"]').forEach((btn: HTMLInputElement) => {
         btn.disabled = true;
         btn.onclick = null;
       });
     };
 
     for (const option of options) {
-      const btn = document.createElement("button");
+      const btn = document.createElement("input");
       btn.type = "button";
-      btn.innerText = option.label;
+      btn.value = option.label;
       btn.onclick = () => {
         clearButtons();
         resolve(option.value);

--- a/src/environment/electron/makeTestScriptEventListenerFactory.ts
+++ b/src/environment/electron/makeTestScriptEventListenerFactory.ts
@@ -1,0 +1,9 @@
+import {TestScript} from "../../script/TestScript";
+import {BrowserWindow} from "electron";
+import {TestScriptEvent, TestScriptListeners} from "../../script/TestScriptEvents";
+
+export const makeTestScriptEventListenerFactory = (script: TestScript, window: BrowserWindow) => {
+  return <E extends TestScriptEvent>(event: E) =>
+    (...args: Parameters<TestScriptListeners[E]>) =>
+      window.webContents.send(event, "", "", script.lineNumber, ...args);
+};

--- a/src/environment/electron/makeTestScriptHandlerFactory.ts
+++ b/src/environment/electron/makeTestScriptHandlerFactory.ts
@@ -1,0 +1,39 @@
+import {TestConfirmFunction, TestScript} from "../../script/TestScript";
+import {BrowserWindow, ipcMain} from "electron";
+import crypto from "node:crypto";
+
+interface SyncHandlers {
+  confirm: TestConfirmFunction;
+}
+
+type SyncHandlersName = keyof SyncHandlers;
+
+export type SyncHandlersMap = {
+  [event in SyncHandlersName]: SyncHandlers[event];
+};
+
+export const makeTestScriptHandlerFactory = (script: TestScript, window: BrowserWindow) => {
+  return <T extends SyncHandlersName, R = ReturnType<SyncHandlersMap[T]>>(event: T) => {
+    return (...args: Parameters<SyncHandlersMap[T]>): Promise<R> => {
+      return new Promise((resolve, reject) => {
+        const errorChannel: string = crypto.randomUUID();
+        const responseChannel: string = crypto.randomUUID();
+
+        const onResponse = (_event: Electron.IpcMainEvent, ret: R): void => {
+          ipcMain.off(errorChannel, onError);
+          resolve(ret);
+        };
+
+        const onError = (_event: Electron.IpcMainEvent, err: Error): void => {
+          ipcMain.off(responseChannel, onResponse);
+          reject(err);
+        };
+
+        ipcMain.once(responseChannel, onResponse);
+        ipcMain.once(errorChannel, onError);
+
+        window.webContents.send(event, responseChannel, errorChannel, script.lineNumber, ...args);
+      });
+    };
+  };
+};

--- a/src/environment/electron/preload.ts
+++ b/src/environment/electron/preload.ts
@@ -27,6 +27,7 @@ const SYS_COL_API: SysColApi = {
   executeScript: (): void => ipcRenderer.send("executeScript"),
   registerEventListener<E extends IpcRendererEvent>(event: E, callback: IpcRendererEventListenerMap[E]): void {
     const ipcListener = async (event: Electron.IpcRendererEvent, responseChannel: string, errorChannel: string, ...parameters: Parameters<IpcRendererEventListenerMap[E]>) => {
+      console.log(...parameters);
       try {
         const ret = await callback.call(null, ...parameters);
         event.sender.send(responseChannel, ret);

--- a/src/environment/electron/preload.ts
+++ b/src/environment/electron/preload.ts
@@ -5,13 +5,14 @@ import {SysColApi} from "./SysColApi";
 type RegisteredEventMap = {
   [event in IpcRendererEvent]: Array<{
     callback: IpcRendererEventListenerMap[event];
-    ipcListener: (_event: Electron.IpcRendererEvent, ...args: Parameters<IpcRendererEventListenerMap[event]>) => void;
+    ipcListener: (event: Electron.IpcRendererEvent, responseChannel: string, errorChannel: string, ...parameters: Parameters<IpcRendererEventListenerMap[event]>) => void;
   }>;
 };
 
 const REGISTERED_EVENTS: RegisteredEventMap = {
   setScriptFileName: [], // unused
   clearLogs: [], // unused
+  confirm: [],
   interrupt: [],
   error: [],
   message: [],
@@ -25,7 +26,15 @@ const REGISTERED_EVENTS: RegisteredEventMap = {
 const SYS_COL_API: SysColApi = {
   executeScript: (): void => ipcRenderer.send("executeScript"),
   registerEventListener<E extends IpcRendererEvent>(event: E, callback: IpcRendererEventListenerMap[E]): void {
-    const ipcListener = (_event: Electron.IpcRendererEvent, ...args: Parameters<IpcRendererEventListenerMap[E]>) => callback.call(null, ...args); // NOSONAR
+    const ipcListener = async (event: Electron.IpcRendererEvent, responseChannel: string, errorChannel: string, ...parameters: Parameters<IpcRendererEventListenerMap[E]>) => {
+      try {
+        const ret = await callback.call(null, ...parameters);
+        event.sender.send(responseChannel, ret);
+      } catch (e) {
+        console.error(e);
+        event.sender.send(errorChannel, e);
+      }
+    };
     REGISTERED_EVENTS[event].push({callback, ipcListener});
     ipcRenderer.on(event, ipcListener);
   },

--- a/src/environment/electron/renderer.ts
+++ b/src/environment/electron/renderer.ts
@@ -1,57 +1,30 @@
-/**
- * This file will automatically be loaded by webpack and run in the "renderer" context.
- * To learn more about the differences between the "main" and the "renderer" context in
- * Electron, visit:
- *
- * https://electronjs.org/docs/latest/tutorial/process-model
- *
- * By default, Node.js integration in this file is disabled. When enabling Node.js integration
- * in a renderer process, please be aware of potential security implications. You can read
- * more about security risks here:
- *
- * https://electronjs.org/docs/tutorial/security
- *
- * To enable Node.js integration in this file, open up `main.js` and enable the `nodeIntegration`
- * flag:
- *
- * ```
- *  // Create the browser window.
- *  mainWindow = new BrowserWindow({
- *    width: 800,
- *    height: 600,
- *    webPreferences: {
- *      nodeIntegration: true
- *    }
- *  });
- * ```
- */
-
 import "../../index.css";
 
-import {clearLogs, getTestResults, logCommand, logCommandResponse, logError, logMessage, logStatus, logTest} from "./index";
+import {clearLogs, confirm, getTestResults, logCommand, logCommandResponse, logError, logMessage, logStatus, logTest} from "./index";
 
-export const setScriptFileName = (file: string): void => {
+export const setScriptFileName = async (file: string): Promise<void> => {
   document.title = file;
-  logStatus(file);
+  return logStatus(file);
 };
 
-const logStarted = () => logStatus("Running...");
+const logStarted = async (): Promise<void> => logStatus("Running...");
 
-const logStopped = (): void => {
+const logStopped = async (): Promise<void> => {
   const tests = getTestResults();
   if (tests.fail) {
-    logStatus(`Tests: ${tests.fail} failed, ${tests.pass + tests.fail} total`, ["tests-passed", "tests-failed"]);
-  } else if (tests.pass) {
-    logStatus(`Tests: ${tests.pass} passed`, ["tests-failed", "tests-passed"]);
-  } else {
-    logStatus("No tests");
+    return logStatus(`Tests: ${tests.fail} failed, ${tests.pass + tests.fail} total`, ["tests-passed", "tests-failed"]);
   }
+  if (tests.pass) {
+    return logStatus(`Tests: ${tests.pass} passed`, ["tests-failed", "tests-passed"]);
+  }
+  return logStatus("No tests");
 };
 
-const logInterrupt = () => logStatus("Interrupt...");
+const logInterrupt = async (): Promise<void> => logStatus("Interrupt...");
 
 SysCol.registerEventListener("setScriptFileName", setScriptFileName);
 SysCol.registerEventListener("clearLogs", clearLogs);
+SysCol.registerEventListener("confirm", confirm);
 SysCol.registerEventListener("error", logError);
 SysCol.registerEventListener("interrupt", logInterrupt);
 SysCol.registerEventListener("message", logMessage);

--- a/src/environment/electron/renderer.ts
+++ b/src/environment/electron/renderer.ts
@@ -4,7 +4,8 @@ import {clearLogs, confirm, getTestResults, logCommand, logCommandResponse, logE
 
 export const setScriptFileName = async (file: string): Promise<void> => {
   document.title = file;
-  return logStatus(file);
+  await clearLogs();
+  return logStatus(file, ["tests-failed tests-passed"]);
 };
 
 const logStarted = async (): Promise<void> => logStatus("Running...");

--- a/src/index.css
+++ b/src/index.css
@@ -56,11 +56,6 @@ html, body {
   cursor: text;
 }
 
-button:disabled {
-  cursor: pointer;
-  color: #AAAAAA;
-}
-
 .sys_col_row:hover {
   /* EMPTY */
 }

--- a/src/index.css
+++ b/src/index.css
@@ -56,6 +56,10 @@ html, body {
   cursor: text;
 }
 
+button:disabled {
+  cursor: pointer;
+  color: #AAAAAA;
+}
 
 .sys_col_row:hover {
   /* EMPTY */

--- a/src/protocols/SysColCommandProtocol.ts
+++ b/src/protocols/SysColCommandProtocol.ts
@@ -3,6 +3,7 @@ import {getTestResult, isTestFailed, isTestPassed} from "./syscol/getTestResult"
 import {parseCommand} from "./syscol/parseCommand";
 import {parseCommandResponse, parseTestResponse} from "./syscol/parseCommandResponse";
 import {stringifyHardwareCommand} from "./syscol/stringifyHardwareCommand";
+import {stringifyHardwareCommandResponse, stringifyTestCommandResponse} from "./syscol/stringifyHardwareCommandResponse";
 
 export class SysColCommandProtocol implements CommandProtocol {
   getTestResult = getTestResult;
@@ -12,4 +13,6 @@ export class SysColCommandProtocol implements CommandProtocol {
   parseCommandResponse = parseCommandResponse;
   parseTestResponse = parseTestResponse;
   stringifyHardwareCommand = stringifyHardwareCommand;
+  stringifyHardwareCommandResponse = stringifyHardwareCommandResponse;
+  stringifyTestCommandResponse = stringifyTestCommandResponse;
 }

--- a/src/protocols/syscol/stringifyHardwareCommandResponse.ts
+++ b/src/protocols/syscol/stringifyHardwareCommandResponse.ts
@@ -1,0 +1,3 @@
+export const stringifyHardwareCommandResponse = (cmd: string, ...args: Array<string>): string => `{${["SC", cmd.toUpperCase(), ...args].join()}}`;
+
+export const stringifyTestCommandResponse = (testId: string, pass: boolean): string => stringifyHardwareCommandResponse("TST", `${testId}:${pass ? "PASS" : "FAIL"}`);

--- a/src/script/CommandProtocol.ts
+++ b/src/script/CommandProtocol.ts
@@ -13,4 +13,6 @@ export interface CommandProtocol {
   parseCommandResponse(str: string): CommandResponse;
   parseTestResponse(str: string): TestResponse;
   stringifyHardwareCommand(cmd: string, ...args: Array<string>): string;
+  stringifyHardwareCommandResponse(cmd: string, ...args: Array<string>): string;
+  stringifyTestCommandResponse(testId: string, pass: boolean): string;
 }

--- a/src/script/TestScript.ts
+++ b/src/script/TestScript.ts
@@ -8,7 +8,7 @@ export type TestConfirmOption = {
   value: string;
 };
 
-export type TestConfirmFunction = (prompt: string, option: TestConfirmOption, ...options: TestConfirmOption[]) => Promise<string>;
+export type TestConfirmFunction = (timeout: number, prompt: string, option: TestConfirmOption, ...options: TestConfirmOption[]) => Promise<string>;
 
 export interface TestScript {
   readonly filePath: string | null;

--- a/src/script/TestScript.ts
+++ b/src/script/TestScript.ts
@@ -3,11 +3,19 @@ import {TestScriptInterruptSignal} from "./TestScriptInterruptController";
 
 export type TestScriptReadyState = "new" | "running" | "stopped";
 
+export type TestConfirmOption = {
+  label: string;
+  value: string;
+};
+
+export type TestConfirmFunction = (prompt: string, option: TestConfirmOption, ...options: TestConfirmOption[]) => Promise<string>;
+
 export interface TestScript {
   readonly filePath: string | null;
   readonly lineNumber: number;
   readonly readyState: TestScriptReadyState;
   signal?: TestScriptInterruptSignal | null;
+  confirm?: TestConfirmFunction | null;
   execute(): Promise<void>;
   on<T extends TestScriptEvent>(event: T, listener: TestScriptListenerMap[T]): void;
   once<T extends TestScriptEvent>(event: T, listener: TestScriptListenerMap[T]): void;

--- a/src/script/TestScriptError.ts
+++ b/src/script/TestScriptError.ts
@@ -1,6 +1,6 @@
 import {TestScript} from "./TestScript";
 
-export type TestScriptErrorName = "FileError" | "HardwareError" | "InterruptError" | "SyntaxError" | "TimeoutError";
+export type TestScriptErrorName = "FileError" | "HardwareError" | "InterruptError" | "InvocationError" | "SyntaxError" | "TimeoutError";
 
 export class TestScriptError {
   stack: Array<{fileName?: string | null; lineNumber: number}> = [];

--- a/src/script/TestScriptImpl.ts
+++ b/src/script/TestScriptImpl.ts
@@ -18,6 +18,7 @@ const getCurrentTimeInMicroseconds = () => (performance.now() * 1_000) | 0;
 
 export class TestScriptImpl implements TestScript {
   signal?: TestScriptInterruptSignal | null;
+  confirm: TestConfirmFunction = null;
   readonly #events = new EventEmitter<string>();
   readonly #filePath?: string | null;
   readonly #text: Array<string>;
@@ -47,8 +48,6 @@ export class TestScriptImpl implements TestScript {
   get readyState(): TestScriptReadyState {
     return this.#readyState;
   }
-
-  confirm: TestConfirmFunction = null;
 
   on<T extends TestScriptEvent>(event: T, listener: TestScriptListenerMap[T]): void {
     this.#events.on(event, listener);
@@ -148,11 +147,13 @@ export class TestScriptImpl implements TestScript {
             this.#serialPort = null;
             break;
           case "confirm":
+            if (argv.length !== 7) throw new TestScriptError("Bad parameters", "SyntaxError");
             try {
-              const ret = await this.confirm?.(argv[0], {label: "Passed", value: "PASS"}, {label: "Failed", value: "FAIL"});
+              const [prompt, testId, , , , , passValue] = argv;
+              const ret = await this.confirm?.(this.#commandTimeout, prompt, {label: argv[2], value: argv[3]}, {label: argv[4], value: argv[5]});
               yield {
                 elapsed: 0,
-                response: `{SC,TST,0.0.0:${ret}}`
+                response: this.#protocol.stringifyTestCommandResponse(testId, ret === passValue),
               };
             } catch (e) {
               throw new TestScriptError(e.message, "InvocationError", e);


### PR DESCRIPTION
Add the possibility to ask a human operator for the result of a test.
This is useful when the result is not automatically available.